### PR TITLE
Provide more schema details on properties

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,8 @@ var (
 	url = "http://localhost:8080/"
 )
 
+// Data is a big data structure we deliver to the web UI as JSON,
+// containing all the information we want to display to users.
 type Data struct {
 	ClusterApps []analysis.ClusterApp
 	Providers   []string
@@ -52,8 +54,10 @@ type Data struct {
 	// List of all properties with hierarchical name
 	PropertyKeys []string
 
-	// Map of properties (key) and array of provides per key
-	PropertiesAndProviders map[string][]string
+	// Map of properties (key) and information per provider.
+	// Example:
+	// "/foo/bar": {"AWS": {"type": ["string"], "title": "...", "description": "..."}}
+	PropertiesAndProviders map[string]map[string]analysis.ProviderPropertySummary
 
 	// Map of features (key) and array of locations where this feature occurs.
 	Features map[string][]string

--- a/pkg/server/static/index.html
+++ b/pkg/server/static/index.html
@@ -27,7 +27,6 @@
           <thead class="table-light" style="position: sticky; top: 0;">
             <tr>
               <th scope="col">Property</th>
-              <th scope="col" class="ctd sorttable_numeric sorttable_sorted_reverse">Providers</th>
             </tr>
           </thead>
           <tbody id="propertiesTableBody">
@@ -152,7 +151,6 @@
         let tbody = table.find('#propertiesTableBody');
         data.PropertyKeys.forEach(prop => {
           let row = $('<tr><th scope="row" class="prop">'+ splitProperty(prop) +'</th></tr>');
-          row.append('<td class="ctd">'+ data.PropertiesAndProviders[prop].length +'</td>');
           data.Providers.forEach(provider => {
             let field = $('<td class="ctd"></td>');
             

--- a/pkg/server/static/index.html
+++ b/pkg/server/static/index.html
@@ -154,7 +154,27 @@
           let row = $('<tr><th scope="row" class="prop">'+ splitProperty(prop) +'</th></tr>');
           row.append('<td class="ctd">'+ data.PropertiesAndProviders[prop].length +'</td>');
           data.Providers.forEach(provider => {
-            row.append('<td class="ctd">'+ (data.PropertiesAndProviders[prop].includes(provider) ? '✅' : '') +'</td>');
+            let field = $('<td class="ctd"></td>');
+            
+            if (typeof data.PropertiesAndProviders[prop][provider] !== 'undefined') {
+              if (data.PropertiesAndProviders[prop][provider].Types && data.PropertiesAndProviders[prop][provider].Types.length) {
+                field.append('<p class="type">' + data.PropertiesAndProviders[prop][provider].Types.join(', ') + '</p>');
+              } else {
+                field.append('<p class="type notype">No type</p>');
+              }
+
+              if (data.PropertiesAndProviders[prop][provider].Title !== '') {
+                field.append('<p class="title">' + data.PropertiesAndProviders[prop][provider].Title + '</p>');
+              } else {
+                field.append('<p class="title notitle">No title</p>');
+              }
+
+              if (data.PropertiesAndProviders[prop][provider].Description !== '') {
+                field.append('<p class="description">' + data.PropertiesAndProviders[prop][provider].Description + '</p>');
+              }
+            }
+
+            row.append(field);
           });
           tbody.append(row);
         });

--- a/pkg/server/static/normalize.css
+++ b/pkg/server/static/normalize.css
@@ -11234,7 +11234,7 @@ textarea.form-control-lg {
 }
 
 .ctd p {
-  margin-bottom: none;
+  margin-bottom: 0px;
   font-size: 0.8rem;
 }
 

--- a/pkg/server/static/normalize.css
+++ b/pkg/server/static/normalize.css
@@ -11233,6 +11233,29 @@ textarea.form-control-lg {
   text-align: center;
 }
 
+.ctd p {
+  margin-bottom: none;
+  font-size: 0.8rem;
+}
+
+p.type {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  font-family: Inconsolata, monospaced;
+}
+
+p.notype {
+  color: red;
+}
+
+p.title {
+  font-weight: bold;
+}
+
+p.notitle {
+  color: red;
+}
+
 .prop {
   font-family: Inconsolata, monospaced;
 }


### PR DESCRIPTION
To allow more detailed comparison of property types, titles, and descriptions, these are now displayed in the table instead of a green checkmark.

The "Provider" column is deleted, as the numerical info makes little sense here.

Before

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/273727/223153435-b454ddab-5617-4e1d-9910-7d39853ca5bf.png">

After

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/273727/223154702-068bd0c5-e719-4f9e-8a31-27bc5c4c5820.png">

